### PR TITLE
Update auto-import.js

### DIFF
--- a/lib/rules/auto-import.js
+++ b/lib/rules/auto-import.js
@@ -11,7 +11,15 @@ var fs = require('fs')
 // Rule Definition
 //------------------------------------------------------------------------------
 
-
+function isStaticRequire(node) {
+  return node &&
+    node.callee &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'require' &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === 'Literal' &&
+    typeof node.arguments[0].value === 'string'
+}
 /**
  * Checks if the given node is the argument of a typeof operator.
  * @param {ASTNode} node The AST node being checked.
@@ -80,8 +88,22 @@ module.exports = {
     create: function(context) {
         var options = context.options[0];
         var considerTypeOf = options && options.typeof === true || false;
+      const dependencies = new Set() // keep track of dependencies
+      let lastNode // keep track of the last node to report on
 
         return {
+          ImportDeclaration(node) {
+            dependencies.add(node.source.value)
+            lastNode = node.source
+          },
+
+          CallExpression(node) {
+            if (isStaticRequire(node)) {
+              const [ requirePath ] = node.arguments
+              dependencies.add(requirePath.value)
+              lastNode = node
+            }
+          },
             "Program:exit": function(/* node */) {
                 var globalScope = context.getScope()
                 var options = context.options[0]
@@ -158,20 +180,20 @@ module.exports = {
                                     if (node.source.value === foundModule) {
                                         if (isNotDefaultExport) {
                                             // add to the named imports of an existing import declaration
-                                            return fixer.insertTextAfter(node.specifiers[node.specifiers.length - 1], ', ' + undefinedIndentifier) 
+                                            return fixer.insertTextAfter(node.specifiers[node.specifiers.length - 1], ', ' + undefinedIndentifier)
                                         } else {
                                             console.log(foundModule, 'already imported')
                                             return
                                         }
                                     }
                                 }
-                                var importStatement = (isNotDefaultExport ? 
+                                var importStatement = (isNotDefaultExport ?
                                     'import { ' + undefinedIndentifier + ' }' :
                                     'import ' + undefinedIndentifier) + " from '" + foundModule + "'"
                                 if (importDeclaration) {
                                     return fixer.insertTextAfter(importDeclaration, '\n' + importStatement)
                                 }
-                                return fixer.insertTextAfterRange([0, 0], importStatement)
+                                return fixer.insertTextAfterRange([0, 0], importStatement + (dependencies.size === 0 ? '\n\n' : ''))
                             }
                         }
                     });

--- a/lib/rules/auto-import.js
+++ b/lib/rules/auto-import.js
@@ -4,12 +4,30 @@
  */
 "use strict";
 
+var tsMorph = require('ts-morph');
+
 var pathModule = require('path')
 var fs = require('fs')
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+function getSourceFile(sourceCode) {
+  const codeProject = new tsMorph.Project({ useInMemoryFileSystem: true });
+
+  return codeProject.createSourceFile('main.tsx', sourceCode);
+}
+
+
+function isDefaultlyExported(path) {
+  const sourceCode = fs.readFileSync(path, {encoding: 'utf8'})
+
+  const sourceFile = getSourceFile(sourceCode)
+
+  
+  return sourceFile.getClasses().find(c => c.isDefaultExport()) !== undefined
+}
 
 function isStaticRequire(node) {
   return node &&
@@ -95,6 +113,10 @@ module.exports = {
           ImportDeclaration(node) {
             dependencies.add(node.source.value)
             lastNode = node.source
+          },
+
+          MemberExpression: function (node) {
+
           },
 
           CallExpression(node) {
@@ -187,9 +209,13 @@ module.exports = {
                                         }
                                     }
                                 }
+
+                                isNotDefaultExport = !isDefaultlyExported(pathModule.dirname(filename) + foundModule.replace('./', '/') + '.ts')
+
                                 var importStatement = (isNotDefaultExport ?
                                     'import { ' + undefinedIndentifier + ' }' :
                                     'import ' + undefinedIndentifier) + " from '" + foundModule + "'"
+
                                 if (importDeclaration) {
                                     return fixer.insertTextAfter(importDeclaration, '\n' + importStatement)
                                 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
-    "requireindex": "~1.1.0"
+    "requireindex": "~1.1.0",
+    "ts-morph": "^9.1.0"
   },
   "devDependencies": {
     "eslint": "^4.7.2"


### PR DESCRIPTION
Fix scenario where when you run fix on a file that originally has no imports to begin with it, the fix will not accurately break line, causing the import to be on the same line as another expression. This commit will ensure the new import correctly breaks line.