### PR TITLE
Add repo info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
     "eslint-plugin"
   ],
   "author": "Kris Zyp",
+  "homepage": "https://github.com/kriszyp/eslint-plugin-auto-import#readme",
+  "bugs": {
+    "url": "https://github.com/kriszyp/eslint-plugin-auto-import/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kriszyp/eslint-plugin-auto-import.git"
+  },
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha tests --recursive"


### PR DESCRIPTION
Without this, there are no links from https://www.npmjs.com/package/eslint-plugin-auto-import to this GitHub repo.